### PR TITLE
remove islandora_image repo

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     "irc": "irc://irc.freenode.net/islandora"
   },
   "require": {
-    "islandora/islandora_image": "dev-8.x-1.x",
+    "islandora/islandora": "dev-8.x-1.x",
     "islandora/openseadragon" : "dev-8.x-1.x",
     "islandora/controlled_access_terms" : "dev-8.x-1.x",
     "drupal/field_group" : "^3.0",

--- a/islandora_demo.info.yml
+++ b/islandora_demo.info.yml
@@ -17,6 +17,7 @@ dependencies:
   - islandora
   - islandora_core_feature
   - islandora_image
+  - islandora_video
   - language
   - link
   - media

--- a/islandora_demo.info.yml
+++ b/islandora_demo.info.yml
@@ -17,7 +17,6 @@ dependencies:
   - islandora
   - islandora_core_feature
   - islandora_image
-  - islandora_video
   - language
   - link
   - media


### PR DESCRIPTION
**GitHub Issue**: (link)
* https://github.com/Islandora-CLAW/islandora/pull/103

# What does this Pull Request do?
* Removes islandora_image module and points to the islandora module.  the image modules is now a sub module of islandora. 

# How should this be tested?
Immediately after https://github.com/Islandora-CLAW/islandora/pull/103 and 

# Interested parties
@Islandora-CLAW/committers
