### PR TITLE
Include new fedoraAdmin role

### DIFF
--- a/config/install/user.role.fedoraadmin.yml
+++ b/config/install/user.role.fedoraadmin.yml
@@ -1,0 +1,9 @@
+langcode: en
+status: true
+dependencies: {  }
+id: fedoraadmin
+label: fedoraAdmin
+weight: 3
+is_admin: null
+permissions: {  }
+


### PR DESCRIPTION
**GitHub Issue**: Part of https://github.com/Islandora-CLAW/CLAW/issues/966

# What does this Pull Request do?

Adds a new `fedoraAdmin` role to allow a Drupal user to have "admin" access to fedora.

# What's new?

* Does this change require documentation to be updated? In general yes, this rolename (specifically only "fedoraAdmin") is required to have super-user access in Fedora, all other users get a `fedoraUser` role and must be allowed via a WebAC rule.

* Does this change add any new dependencies? no
* Does this change require any other modifications to be made to the repository
 (ie. Regeneration activity, etc.)? no
* Could this change impact execution of existing code? no

# How should this be tested?

Doesn't do anything but add a new Drupal role.

# Additional Notes:
This will help with the testing of a bunch of coming PRs.

# Interested parties
@Islandora-CLAW/committers, @dannylamb 
